### PR TITLE
Changes must be a dict

### DIFF
--- a/_states/logging.py
+++ b/_states/logging.py
@@ -21,35 +21,35 @@ def __virtual__():
 
 def debug(name, obj, string = ''):
     ret = {'name': name,
-           'changes': [],
+           'changes': {},
            'result': True,
            'comment': __salt__['logger.debug'](obj, string)}
     return ret
 
 def info(name, obj, string = ''):
     ret = {'name': name,
-           'changes': [],
+           'changes': {},
            'result': True,
            'comment': __salt__['logger.info'](obj, string)}
     return ret
 
 def warning(name, obj, string = ''):
     ret = {'name': name,
-           'changes': [],
+           'changes': {},
            'result': True,
            'comment': __salt__['logger.warning'](obj, string)}
     return ret
 
 def error(name, obj, string = ''):
     ret = {'name': name,
-           'changes': [],
+           'changes': {},
            'result': True,
            'comment': __salt__['logger.error'](obj, string)}
     return ret
 
 def critical(name, obj, string = ''):
     ret = {'name': name,
-           'changes': [],
+           'changes': {},
            'result': True,
            'comment': __salt__['logger.critical'](obj, string)}
     return ret


### PR DESCRIPTION
As of 2018.3.2 (Oxygen) unless changes is a dictionary, an exception is thrown:

The State execution failed to record the order in which all states were executed. The state return missing data is:
{u'changes': {},
 u'comment': u"An exception occurred in this state: 'Changes' should be a dictionary.",
 u'name': u'later',
 u'result': False}